### PR TITLE
Do not send more than our buffer size

### DIFF
--- a/include/comm.h
+++ b/include/comm.h
@@ -23,7 +23,7 @@ bool queryRegistry(char regID, char *buffer)
 
   //Sending command to serial
   MySerial.flush(); //Prevent possible pending info on the read
-  MySerial.write(prep);
+  MySerial.write(prep, 4);
   ulong start = millis();
 
   int len = 0;


### PR DESCRIPTION
The `prep` buffer is not guaranteed to be NULL-terminated, so make sure we send only 4 bytes.