### PR TITLE
Revert "Do not send more than our buffer size"

### DIFF
--- a/include/comm.h
+++ b/include/comm.h
@@ -23,7 +23,7 @@ bool queryRegistry(char regID, char *buffer)
 
   //Sending command to serial
   MySerial.flush(); //Prevent possible pending info on the read
-  MySerial.write(prep, 4);
+  MySerial.write(prep);
   ulong start = millis();
 
   int len = 0;


### PR DESCRIPTION
Reverts raomin/ESPAltherma#19
no instance of overloaded function "HardwareSerial::write" matches the argument list -- argument types are: (char [4], int) 

I'll make `prep` a char [5] and set the last byte as \0.