### PR TITLE
Prevent array overflow when initializing registry

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,7 +119,12 @@ void initRegistries(){
   int i = 0;
   for (auto &&label : labelDefs)
   {
-    if (!contains(registryIDs, sizeof(registryIDs), label.registryID))
+    if (i >= sizeof(registryIDs))
+    {
+      mqttSerial.printf("Exceeding maximum number of registry entries (%d) to be queried.\n", sizeof(registryIDs));
+      break;
+    }
+    else if (!contains(registryIDs, sizeof(registryIDs), label.registryID))
     {
       mqttSerial.printf("Adding registry 0x%2x to be queried.\n", label.registryID);
       registryIDs[i++] = label.registryID;


### PR DESCRIPTION
When collecting all enabled label definitions from the heat pump model's header
file, the corresponding registry IDs are collected in an array.
The problem is that the array can hold at most 32 elements but there are more
registry entries in the header that can be potentially added to the registry
array. Basically, this can result in an array overflow when more than 32
registry entries are enabled (uncommented) in the header file.