### PR TITLE
Fix serial write API to make sure all bytes are transmitted

### DIFF
--- a/include/comm.h
+++ b/include/comm.h
@@ -18,7 +18,7 @@ bool queryRegistry(char regID, char *buffer)
 {
 
   //preparing command:
-  char prep[] = {0x03, 0x40, regID, 0x00, 0x00};
+  char prep[] = {0x03, 0x40, regID, 0x00};
   prep[3] = getCRC(prep, 3);
 
   //Sending command to serial

--- a/include/comm.h
+++ b/include/comm.h
@@ -23,7 +23,7 @@ bool queryRegistry(char regID, char *buffer)
 
   //Sending command to serial
   MySerial.flush(); //Prevent possible pending info on the read
-  MySerial.write(prep, sizeof(prep));
+  MySerial.write(prep, 4);
   ulong start = millis();
 
   int len = 0;

--- a/include/comm.h
+++ b/include/comm.h
@@ -23,7 +23,7 @@ bool queryRegistry(char regID, char *buffer)
 
   //Sending command to serial
   MySerial.flush(); //Prevent possible pending info on the read
-  MySerial.write(prep);
+  MySerial.write(prep, sizeof(prep));
   ulong start = millis();
 
   int len = 0;


### PR DESCRIPTION
We need to use the serial write API where the amount of bytes to be sent can be
chosen. That way, commands that contain a 0 byte are transmitted correctly.

When using the old API, the array that shall be sent is interpreted as a
C string. Therefore, any byte before a 0 byte in the array is seen as the last
byte to be sent.

Actual bug:
When querying register 0 from the heat pump, the third byte in the packet to be
sent is a 0 byte. Therefore, only the first two bytes (which are preceeding the
0 byte) are actually sent. The register ID (which is 0) and the two CRC bytes
are skipped.
The heat pump answers with 0x15 0xea which more or less means "query not
understood".