### PR TITLE
Support for NodeMCUv2/ESP-12E/ESP8266 board

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 env:
 
 install:
-    - pip install --upgrade pip setuptools
+    - pip install --upgrade pip setuptools importlib-metadata
     - pip install -U platformio
     - pio pkg install
     - pio pkg update

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,11 @@ cache:
 env:
 
 install:
+    - pip install --upgrade pip setuptools
     - pip install -U platformio
-    - pio update
+    - pio pkg install
+    - pio pkg update
 
-    #
-    # Libraries from PlatformIO Library Registry:
-    #
-    - pio lib -g install 89 6246
 
 script:
-    - pio ci --board=esp32doit-devkit-v1 --board=m5stick-c --lib="." src
+    - pio ci --project-conf=platformio.ini --lib="." src

--- a/include/comm.h
+++ b/include/comm.h
@@ -2,9 +2,6 @@
 #include <HardwareSerial.h>
 #ifdef ARDUINO_ARCH_ESP8266
 #include <SoftwareSerial.h>
-#endif
-
-#ifdef ARDUINO_ARCH_ESP8266
 SoftwareSerial MySerial;
 #define SERIAL_CONFIG (SWSERIAL_8E1)
 #else

--- a/include/comm.h
+++ b/include/comm.h
@@ -52,7 +52,7 @@ bool queryRegistry(char regID, char *buffer)
     {
       mqttSerial.printf("ERR: Time out on register 0x%02x! got %d/%d bytes\n", regID, len, buffer[2]);
       char bufflog[250] = {0};
-      for (size_t i = 0; i < len; i++)
+      for (int i = 0; i < len; i++)
       {
         sprintf(bufflog + i * 5, "0x%02x ", buffer[i]);
       }

--- a/include/comm.h
+++ b/include/comm.h
@@ -1,7 +1,16 @@
 #include <Arduino.h>
 #include <HardwareSerial.h>
+#ifdef ARDUINO_ARCH_ESP8266
+#include <SoftwareSerial.h>
+#endif
 
+#ifdef ARDUINO_ARCH_ESP8266
+SoftwareSerial MySerial;
+#define SERIAL_CONFIG (SWSERIAL_8E1)
+#else
 HardwareSerial MySerial(1);
+#define SERIAL_CONFIG (SERIAL_8E1)
+#endif
 #define SER_TIMEOUT 300 //leave 300ms for the machine to answer
 
 char getCRC(char *src, int len)

--- a/include/converters.h
+++ b/include/converters.h
@@ -31,7 +31,7 @@ public:
         LabelDef *labels[128];
         getLabels(registryID, labels, num);
 
-        for (size_t i = 0; i < num; i++)
+        for (int i = 0; i < num; i++)
         {
             char *input = data;
             input += labels[i]->offset + 3;
@@ -46,7 +46,7 @@ public:
         int num = def->dataSize;
         double dblData = NAN;
         Serial.print("Converting from:");
-        for (size_t i = 0; i < num; i++)
+        for (int i = 0; i < num; i++)
         {
             Serial.printf(" 0x%02x ", data[i]);
         }

--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -25,7 +25,7 @@ void sendValues()
   snprintf(jsonbuff + strlen(jsonbuff),MAX_MSG_SIZE - strlen(jsonbuff) , "\"%s\":\"%.3gV\",\"%s\":\"%gmA\",", "M5VIN", M5.Axp.GetVinVoltage(),"M5AmpIn", M5.Axp.GetVinCurrent());
   snprintf(jsonbuff + strlen(jsonbuff),MAX_MSG_SIZE - strlen(jsonbuff) , "\"%s\":\"%.3gV\",\"%s\":\"%gmA\",", "M5BatV", M5.Axp.GetBatVoltage(),"M5BatCur", M5.Axp.GetBatCurrent());
   snprintf(jsonbuff + strlen(jsonbuff),MAX_MSG_SIZE - strlen(jsonbuff) , "\"%s\":\"%.3gmW\",", "M5BatPwr", M5.Axp.GetBatPower());
-#endif  
+#endif
   snprintf(jsonbuff + strlen(jsonbuff),MAX_MSG_SIZE - strlen(jsonbuff) , "\"%s\":\"%ddBm\",", "WifiRSSI", WiFi.RSSI());
 
   jsonbuff[strlen(jsonbuff) - 1] = '}';
@@ -73,7 +73,7 @@ void reconnect()
       client.publish("homeassistant/sensor/espAltherma/config", "{\"name\":\"AlthermaSensors\",\"stat_t\":\"~/STATESENS\",\"avty_t\":\"~/LWT\",\"pl_avail\":\"Online\",\"pl_not_avail\":\"Offline\",\"uniq_id\":\"espaltherma\",\"device\":{\"identifiers\":[\"ESPAltherma\"]}, \"~\":\"espaltherma\",\"json_attr_t\":\"~/ATTR\"}", true);
       client.publish(MQTT_lwt, "Online", true);
       client.publish("homeassistant/switch/espAltherma/config", "{\"name\":\"Altherma\",\"cmd_t\":\"~/POWER\",\"stat_t\":\"~/STATE\",\"pl_off\":\"OFF\",\"pl_on\":\"ON\",\"~\":\"espaltherma\"}", true);
- 
+
       // Subscribe
       client.subscribe("espaltherma/POWER");
 #ifdef PIN_SG1
@@ -101,9 +101,9 @@ void reconnect()
 void callbackTherm(byte *payload, unsigned int length)
 {
   payload[length] = '\0';
-  
+
   // Is it ON or OFF?
-  // Ok I'm not super proud of this, but it works :p 
+  // Ok I'm not super proud of this, but it works :p
   if (payload[1] == 'F')
   { //turn off
     digitalWrite(PIN_THERM, HIGH);
@@ -119,11 +119,11 @@ void callbackTherm(byte *payload, unsigned int length)
     mqttSerial.println("Turned ON");
   }
   else if (payload[0] == 'R')//R(eset/eboot)
-  { 
+  {
     mqttSerial.println("Rebooting");
     delay(100);
     restart_board();
-  }  
+  }
   else
   {
     Serial.printf("Unknown message: %s\n", payload);
@@ -135,7 +135,7 @@ void callbackTherm(byte *payload, unsigned int length)
 void callbackSg(byte *payload, unsigned int length)
 {
   payload[length] = '\0';
-  
+
   if (payload[0] == '0')
   {
     // Set SG 0 mode => SG1 = INACTIVE, SG2 = INACTIVE

--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -1,5 +1,7 @@
 #include <PubSubClient.h>
 #include <EEPROM.h>
+#include "restart.h"
+
 #define MQTT_attr "espaltherma/ATTR"
 #define MQTT_lwt "espaltherma/LWT"
 
@@ -90,7 +92,7 @@ void reconnect()
 
       if (i++ == 100)
         Serial.printf("Tried for 500 sec, rebooting now.");
-        esp_restart();
+        restart_board();
     }
   }
 }
@@ -119,7 +121,7 @@ void callbackTherm(byte *payload, unsigned int length)
   { 
     mqttSerial.println("Rebooting");
     delay(100);
-    esp_restart();
+    restart_board();
   }  
   else
   {

--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -90,9 +90,10 @@ void reconnect()
         ArduinoOTA.handle();
       }
 
-      if (i++ == 100)
+      if (i++ == 100) {
         Serial.printf("Tried for 500 sec, rebooting now.");
         restart_board();
+      }
     }
   }
 }

--- a/include/restart.h
+++ b/include/restart.h
@@ -1,3 +1,6 @@
+#ifndef ESPALTHERMA_RESTART_H
+#define ESPALTHERMA_RESTART_H
+
 #include <Arduino.h>
 
 void restart_board()
@@ -8,3 +11,5 @@ void restart_board()
   esp_restart();
   #endif
 }
+
+#endif

--- a/include/restart.h
+++ b/include/restart.h
@@ -1,0 +1,10 @@
+#include <Arduino.h>
+
+void restart_board()
+{
+  #if defined(ARDUINO_ARCH_ESP8266)
+  system_restart();
+  #else
+  esp_restart();
+  #endif
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,6 +12,16 @@
 [platformio]
 default_envs = esp32
 
+[env:nodemcuv2]
+platform = espressif8266
+framework = arduino
+board = nodemcuv2
+monitor_speed = 115200
+upload_speed = 921600
+build_flags = -D_GNU_SOURCE
+lib_deps =
+	PubSubClient
+
 [env:esp32]
 platform = espressif32
 board = esp32doit-devkit-v1
@@ -21,7 +31,7 @@ upload_speed = 115200
 ; Uncomment this line to allow for remote upgrade. If name resolution does not work for you, replace with the IP of ESPAltherma
 ; upload_port = ESPAltherma.local
 
-lib_deps = 
+lib_deps =
 	PubSubClient
 
 [env:m5stickc]
@@ -33,7 +43,7 @@ upload_speed = 115200
 ; Uncomment this line to allow for remote upgrade. If name resolution does not work for you, replace with the IP of ESPAltherma
 ; upload_port = ESPAltherma.local
 
-lib_deps = 
+lib_deps =
 	M5StickC
 	PubSubClient
 
@@ -46,7 +56,7 @@ upload_speed = 115200
 ; Uncomment this line to allow for remote upgrade. If name resolution does not work for you, replace with the IP of ESPAltherma
 ; upload_port = ESPAltherma.local
 
-lib_deps = 
+lib_deps =
 	M5StickCPlus
 	PubSubClient
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,7 +48,7 @@ void updateValues(char regID)
   LabelDef *labels[128];
   int num = 0;
   converter.getLabels(regID, labels, num);
-  for (size_t i = 0; i < num; i++)
+  for (int i = 0; i < num; i++)
   {
     bool alpha = false;
     for (size_t j = 0; j < strlen(labels[i]->asString); j++)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,8 +64,8 @@ void updateValues(char regID)
     strcat(topicBuff,labels[i]->label);
     client.publish(topicBuff, labels[i]->asString);
     #endif
-    
-    if (alpha){      
+
+    if (alpha){
       snprintf(jsonbuff + strlen(jsonbuff), MAX_MSG_SIZE - strlen(jsonbuff), "\"%s\":\"%s\",", labels[i]->label, labels[i]->asString);
     }
     else{//number, no quotes
@@ -102,7 +102,7 @@ void setup_wifi()
   delay(10);
   // We start by connecting to a WiFi network
   mqttSerial.printf("Connecting to %s\n", WIFI_SSID);
-  
+
   #if defined(WIFI_IP) && defined(WIFI_GATEWAY) && defined(WIFI_SUBNET)
     IPAddress local_IP(WIFI_IP);
     IPAddress gateway(WIFI_GATEWAY);
@@ -123,7 +123,7 @@ void setup_wifi()
     if (!WiFi.config(local_IP, gateway, subnet, primaryDNS, secondaryDNS)) {
       mqttSerial.println("Failed to set static ip!");
     }
-  #endif  
+  #endif
 
   WiFi.begin(WIFI_SSID, WIFI_PWD);
   int i = 0;
@@ -140,12 +140,12 @@ void setup_wifi()
 }
 
 void initRegistries(){
-    //getting the list of registries to query from the selected values  
+    //getting the list of registries to query from the selected values
   for (size_t i = 0; i < sizeof(registryIDs); i++)
   {
     registryIDs[i]=0xff;
   }
-  
+
   int i = 0;
   for (auto &&label : labelDefs)
   {
@@ -199,7 +199,7 @@ void setup()
   digitalWrite(PIN_SG2, SG_RELAY_INACTIVE_STATE);
   pinMode(PIN_SG1, OUTPUT);
   pinMode(PIN_SG2, OUTPUT);
- 
+
 #endif
 #ifdef ARDUINO_M5Stick_C_Plus
   gpio_pulldown_dis(GPIO_NUM_25);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include "converters.h"
 #include "comm.h"
 #include "mqtt.h"
+#include "restart.h"
 
 Converter converter;
 char registryIDs[32]; //Holds the registries to query

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,8 +6,14 @@
 #include <Arduino.h>
 #endif
 
-#include <HardwareSerial.h>
+#ifdef ARDUINO_ARCH_ESP8266
+#include <SoftwareSerial.h>
+#include <ESP8266WiFi.h>
+#else
 #include <WiFi.h>
+#endif
+#include <HardwareSerial.h>
+
 #include <PubSubClient.h>
 #include <ArduinoOTA.h>
 
@@ -182,7 +188,7 @@ void setup()
 {
   Serial.begin(115200);
   setupScreen();
-  MySerial.begin(9600, SERIAL_8E1, RX_PIN, TX_PIN);
+  MySerial.begin(9600, SERIAL_CONFIG, RX_PIN, TX_PIN);
   pinMode(PIN_THERM, OUTPUT);
   digitalWrite(PIN_THERM, HIGH);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -132,7 +132,7 @@ void setup_wifi()
     Serial.print(".");
     if (i++ == 100)
     {
-      esp_restart();
+      restart_board();
     }
   }
   mqttSerial.printf("Connected. IP Address: %s\n", WiFi.localIP().toString().c_str());
@@ -216,7 +216,7 @@ void setup()
 
   ArduinoOTA.onError([](ota_error_t error) {
     mqttSerial.print("Error on OTA - restarting");
-    esp_restart();
+    restart_board();
   });
   ArduinoOTA.begin();
 


### PR DESCRIPTION
Thanks for such a great project. I didn't have an ESP32, but I did have a spare NodeMCU, so I had a go at getting it working on there. Mine is actually an ESP-12F, but PlatformIO didn't list that one so I've just used it as "[NodeMCU 1.0 (ESP-12E Module)](https://docs.platformio.org/en/stable/boards/espressif8266/nodemcuv2.html)" . This PR is the result. It seems to work OK with my EHBX16CB3V + ERLQ016CAV3. 

Only very basic figures so far, but I'll get on with setting up more over the next few days: 
![image](https://user-images.githubusercontent.com/6237786/176131287-10b7e473-40c5-4439-aae7-a11982f12c2f.png)

I noted the comments in #14 that using a software serial library might work, so that is what I have done. The only other major change was to abstract out the restart function. 

I also added the build flag `-D_GNU_SOURCE` to stop messages like this appearing: 
![image](https://user-images.githubusercontent.com/6237786/176133291-2ad4ea9e-61e8-4332-bf1d-319c7eff0efd.png)

The only other thing that needs to be changed is dropping the `PROGMEM` part of the `LabelDef` declaration in your chosen definitions file. Otherwise the board won't even boot. 

The only thing that I think could be improved is that you can't connect to the monitor or flash the firmware over USB when the pins are connected to the X10A. Connecting to the monitor first and then connecting the pins to the X10A works fine. 

Also it seems that it can't be powered from the X10A interface so I'm powering direct from USB. 

I hope this is useful to others. I haven't been able to test that it doesn't break the ESP32 or M5StickC setups as I don't have either of those. 

Thanks again for all your efforts on this, it is really useful!

Fixes #14, fixes #65, fixes #71