### PR TITLE
Restart device if no WiFi is available for 60 secs

### DIFF
--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -62,7 +62,7 @@ void readEEPROM(){
   }
 }
 
-void reconnect()
+void reconnectMqtt()
 {
   // Loop until we're reconnected
   int i = 0;


### PR DESCRIPTION
Some AccessPoints disconnect clients really dirty. The clients are not able to reconnect except rebooting the devices. I could not figure out what exactly the problem is (happened multiple times with different APs so far), but this pull request offers a passive aggressive solution rebooting the board if no wifi connection is possible within 60 seconds. 