### PR TITLE
Negative values as numeric type

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,8 +54,9 @@ void updateValues(char regID)
     for (size_t j = 0; j < strlen(labels[i]->asString); j++)
     {
       char c = labels[i]->asString[j];
-      if (!isdigit(c) && c!='.'){
+      if (!isdigit(c) && c!='.' && !(c=='-' && j==0)){
         alpha = true;
+        break;
       }
     }
 


### PR DESCRIPTION
Negative numbers will be added to json as numeric type instead of string. And only if minus sign is the first character, since converter might also return "---", which is not numeric. And there is no need to check all of the remaining characters in string, if alpha condition is met. Breaking out of the loop immediately.