### PR TITLE
Improved Homeassistant MQTT Discovery

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,8 +197,12 @@ void setup()
   Serial.begin(115200);
   setupScreen();
   MySerial.begin(9600, SERIAL_CONFIG, RX_PIN, TX_PIN);
+
+#ifdef PIN_THERM
+  // Thermostat relay - Set first to the inactive state, before configuring as outputs (avoid false triggering when initializing)
+  digitalWrite(PIN_THERM, THERM_RELAY_INACTIVE_STATE);
   pinMode(PIN_THERM, OUTPUT);
-  digitalWrite(PIN_THERM, HIGH);
+#endif
 
 #ifdef PIN_SG1
   //Smartgrid pins - Set first to the inactive state, before configuring as outputs (avoid false triggering when initializing)

--- a/src/setup.h
+++ b/src/setup.h
@@ -27,7 +27,21 @@
 #define TX_PIN    17// Pin connected to the RX pin of X10A
 #endif
 
+//Thermostat control - Optional:
 #define PIN_THERM 0// Pin connected to the thermostat relay (normally open)
+// Define if your THERM relay board is Low or High triggered (signal pins)
+// Only uncomment one of them
+//#define THERM_RELAY_HIGH_TRIGGER
+#define THERM_RELAY_LOW_TRIGGER
+
+// DO NOT CHANGE: Defines the SG active/inactive relay states, according to the definition of the trigger status
+#if defined(THERM_RELAY_LOW_TRIGGER)
+#define THERM_RELAY_ACTIVE_STATE LOW
+#define THERM_RELAY_INACTIVE_STATE HIGH
+#else
+#define THERM_RELAY_ACTIVE_STATE HIGH
+#define THERM_RELAY_INACTIVE_STATE LOW
+#endif
 
 //Smart grid control - Optional:
 //Uncomment and set to enable SG mqtt functions


### PR DESCRIPTION
- Improved Homeassistant MQTT discovery: all ESPAltherma's entities should apear under the same device.
- Make the thermostat relay (switch) optional, allowing users to disable it (by not defining its pin) so it doesn't show up on home assistant.
- Added the option to change the active level for the thermostat relay