### PR TITLE
FIX: Smart grid operating mode MQTT discovery.

### DIFF
--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -80,8 +80,14 @@ void reconnectMqtt()
       // Subscribe
       client.subscribe("espaltherma/POWER");
 #ifdef PIN_SG1
-      client.publish("homeassistant/sg/espAltherma/config", "{\"name\":\"AlthermaSmartGrid\",\"cmd_t\":\"~/set\",\"stat_t\":\"~/state\",\"~\":\"espaltherma/sg\"}", true);
+      // Smart Grid
+      client.publish("homeassistant/select/espAltherma/sg/config", "{\"availability\":[{\"topic\":\"espaltherma/LWT\",\"payload_available\":\"Online\",\"payload_not_available\":\"Offline\"}],\"availability_mode\":\"all\",\"unique_id\":\"espaltherma_sg\",\"device\":{\"identifiers\":[\"ESPAltherma\"],\"manufacturer\":\"ESPAltherma\",\"model\":\"M5StickC PLUS ESP32-PICO\",\"name\":\"ESPAltherma\"},\"icon\":\"mdi:solar-power\",\"name\":\"EspAltherma Smart Grid\",\"command_topic\":\"espaltherma/sg/set\",\"command_template\":\"{% if value == 'Free Running' %} 0 {% elif value == 'Forced Off' %} 1 {% elif value == 'Recommended On' %} 2 {% elif value == 'Forced On' %} 3 {% else %} 0 {% endif %}\",\"options\":[\"Free Running\",\"Forced Off\",\"Recommended On\",\"Forced On\"],\"state_topic\":\"espaltherma/sg/state\",\"value_template\":\"{% set mapper = { '0':'Free Running', '1':'Forced Off', '2':'Recommended On', '3':'Forced On' } %} {% set word = mapper[value] %} {{ word }}\"}", true);
       client.subscribe("espaltherma/sg/set");
+      client.publish("espaltherma/sg/state", "0");
+#endif
+#ifndef PIN_SG1
+      // Publish empty retained message so discovered entities are removed from HA
+      client.publish("homeassistant/select/espAltherma/sg/config", "", true);
 #endif
     }
     else


### PR DESCRIPTION
Its showing now as a select entity on HA, on the same device as the rest of the entities. The payload needed to trigger each mode is unchanged, the conversion is handled by ha using templates.

ToDo: (in a new PR) S4S (energy meter pulse output) signal generation, so smart grid is fully operational.

CLOSES: #234 

The S4S signal (energy pulse meter otput) IS NOT implemented in this PR. It will implemented in a separated PR