### PR TITLE
NEW: Support for themad shapping signals via X85A port

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -206,8 +206,20 @@ void setup()
   digitalWrite(PIN_SG2, SG_RELAY_INACTIVE_STATE);
   pinMode(PIN_SG1, OUTPUT);
   pinMode(PIN_SG2, OUTPUT);
-
 #endif
+
+#ifdef PIN_L1
+  // Demand Shapping X85A pins - Set first to the inactive state, before configuring as outputs (avoid false triggering when initializing)
+  digitalWrite(PIN_L1, X85A_RELAY_INACTIVE_STATE);
+  digitalWrite(PIN_L2, X85A_RELAY_INACTIVE_STATE);
+  digitalWrite(PIN_L3, X85A_RELAY_INACTIVE_STATE);
+  digitalWrite(PIN_L4, X85A_RELAY_INACTIVE_STATE);
+  pinMode(PIN_L1, OUTPUT);
+  pinMode(PIN_L2, OUTPUT);
+  pinMode(PIN_L3, OUTPUT);
+  pinMode(PIN_L4, OUTPUT);
+#endif
+
 #ifdef ARDUINO_M5Stick_C_Plus
   gpio_pulldown_dis(GPIO_NUM_25);
   gpio_pullup_dis(GPIO_NUM_25);

--- a/src/setup.h
+++ b/src/setup.h
@@ -47,6 +47,26 @@
 #define SG_RELAY_INACTIVE_STATE LOW
 #endif
 
+//Demand shapping control X85A - Optional:
+//Uncomment and set to enable X85A mqtt functions
+//#define PIN_L1 27// Pin connected to dry contact SG 1 relay (normally open)
+//#define PIN_L2 14// Pin connected to dry contact SG 2 relay (normally open)
+//#define PIN_L3 12// Pin connected to dry contact SG 2 relay (normally open)
+//#define PIN_L4 13// Pin connected to dry contact SG 2 relay (normally open)
+// Define if your SG relay board is Low or High triggered (signal pins)
+// Only uncomment one of them
+//#define X85A_RELAY_HIGH_TRIGGER
+//#define X85A_RELAY_LOW_TRIGGER
+
+// DO NOT CHANGE: Defines the SG active/inactive relay states, according to the definition of the trigger status
+#if defined(X85A_RELAY_LOW_TRIGGER)
+#define X85A_RELAY_ACTIVE_STATE LOW
+#define X85A_RELAY_INACTIVE_STATE HIGH
+#else
+#define X85A_RELAY_ACTIVE_STATE HIGH
+#define X85A_RELAY_INACTIVE_STATE LOW
+#endif
+
 #define MAX_MSG_SIZE 5120//max size of the json message sent in mqtt 
 
 //Uncomment this line if the JSON message should be in a Json Table format []. Use only for IOBroker Vis. 


### PR DESCRIPTION
Adds support for X85A 4 level power limitation (as implemented by the demand shapping PCB), disussed in https://github.com/raomin/ESPAltherma/discussions/170

It is not possible to enable several output at the same time, even if that is supported by daikin, since the unit will only follow the most restrictive input.

ie: if level 1 limits the power to 5kw and level 2 limits the power to 3kw, and bot inputs are active, the unit will be limited to 3kw, so the level 1 input has no effect)