### PR TITLE
add support for PCA9554PW Port Expander

### DIFF
--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -50,7 +50,11 @@ void saveEEPROM(uint8_t state){
 
 void readEEPROM(){
   if ('R' == EEPROM.read(EEPROM_CHK)){
-    digitalWrite(PIN_THERM,EEPROM.read(EEPROM_STATE));
+    #ifdef IO_EXPANDER
+      ioCon1.digitalWrite(PIN_THERM,EEPROM.read(EEPROM_STATE));
+    #else
+      digitalWrite(PIN_THERM,EEPROM.read(EEPROM_STATE));
+    #endif
     mqttSerial.printf("Restoring previous state: %s",(EEPROM.read(EEPROM_STATE) == HIGH)? "Off":"On" );
   }
   else{
@@ -58,7 +62,11 @@ void readEEPROM(){
     EEPROM.write(EEPROM_CHK,'R');
     EEPROM.write(EEPROM_STATE,HIGH);
     EEPROM.commit();
-    digitalWrite(PIN_THERM,HIGH);
+    #ifdef IO_EXPANDER
+      ioCon1.digitalWrite(PIN_THERM,HIGH);
+    #else
+      digitalWrite(PIN_THERM,HIGH);
+    #endif
   }
 }
 
@@ -115,14 +123,22 @@ void callbackTherm(byte *payload, unsigned int length)
   // Ok I'm not super proud of this, but it works :p
   if (payload[1] == 'F')
   { //turn off
-    digitalWrite(PIN_THERM, HIGH);
+    #ifdef IO_EXPANDER
+      ioCon1.digitalWrite(PIN_THERM,HIGH);
+    #else
+      digitalWrite(PIN_THERM,HIGH);
+    #endif
     saveEEPROM(HIGH);
     client.publish("espaltherma/STATE", "OFF", true);
     mqttSerial.println("Turned OFF");
   }
   else if (payload[1] == 'N')
   { //turn on
-    digitalWrite(PIN_THERM, LOW);
+    #ifdef IO_EXPANDER
+      ioCon1.digitalWrite(PIN_THERM,LOW);
+    #else
+      digitalWrite(PIN_THERM,LOW);
+    #endif
     saveEEPROM(LOW);
     client.publish("espaltherma/STATE", "ON", true);
     mqttSerial.println("Turned ON");
@@ -148,32 +164,52 @@ void callbackSg(byte *payload, unsigned int length)
   if (payload[0] == '0')
   {
     // Set SG 0 mode => SG1 = INACTIVE, SG2 = INACTIVE
+  #ifdef IO_EXPANDER
+    ioCon1.digitalWrite(PIN_SG1, SG_RELAY_INACTIVE_STATE);
+    ioCon1.digitalWrite(PIN_SG2, SG_RELAY_INACTIVE_STATE);
+  #else
     digitalWrite(PIN_SG1, SG_RELAY_INACTIVE_STATE);
     digitalWrite(PIN_SG2, SG_RELAY_INACTIVE_STATE);
+  #endif
     client.publish("espaltherma/sg/state", "0");
     Serial.println("Set SG mode to 0 - Normal operation");
   }
   else if (payload[0] == '1')
   {
     // Set SG 1 mode => SG1 = INACTIVE, SG2 = ACTIVE
+  #ifdef IO_EXPANDER
+    ioCon1.digitalWrite(PIN_SG1, SG_RELAY_INACTIVE_STATE);
+    ioCon1.digitalWrite(PIN_SG2, SG_RELAY_ACTIVE_STATE);
+  #else
     digitalWrite(PIN_SG1, SG_RELAY_INACTIVE_STATE);
     digitalWrite(PIN_SG2, SG_RELAY_ACTIVE_STATE);
+  #endif
     client.publish("espaltherma/sg/state", "1");
     Serial.println("Set SG mode to 1 - Forced OFF");
   }
   else if (payload[0] == '2')
   {
     // Set SG 2 mode => SG1 = ACTIVE, SG2 = INACTIVE
+  #ifdef IO_EXPANDER
+    ioCon1.digitalWrite(PIN_SG1, SG_RELAY_ACTIVE_STATE);
+    ioCon1.digitalWrite(PIN_SG2, SG_RELAY_INACTIVE_STATE);
+  #else
     digitalWrite(PIN_SG1, SG_RELAY_ACTIVE_STATE);
     digitalWrite(PIN_SG2, SG_RELAY_INACTIVE_STATE);
+  #endif
     client.publish("espaltherma/sg/state", "2");
     Serial.println("Set SG mode to 2 - Recommended ON");
   }
   else if (payload[0] == '3')
   {
     // Set SG 3 mode => SG1 = ACTIVE, SG2 = ACTIVE
+  #ifdef IO_EXPANDER
+    ioCon1.digitalWrite(PIN_SG1, SG_RELAY_ACTIVE_STATE);
+    ioCon1.digitalWrite(PIN_SG2, SG_RELAY_ACTIVE_STATE);
+  #else
     digitalWrite(PIN_SG1, SG_RELAY_ACTIVE_STATE);
     digitalWrite(PIN_SG2, SG_RELAY_ACTIVE_STATE);
+  #endif
     client.publish("espaltherma/sg/state", "3");
     Serial.println("Set SG mode to 3 - Forced ON");
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,13 @@
 #include <ArduinoOTA.h>
 
 #include "setup.h" //<-- Configure your setup here
+
+#ifdef IO_EXPANDER
+  #include "PCA9554.h"
+  #include <Wire.h>
+  PCA9554 ioCon1(0x27);
+#endif
+
 #include "mqttserial.h"
 #include "converters.h"
 #include "comm.h"
@@ -200,15 +207,31 @@ void setup()
   Serial.begin(115200);
   setupScreen();
   MySerial.begin(9600, SERIAL_CONFIG, RX_PIN, TX_PIN);
-  pinMode(PIN_THERM, OUTPUT);
-  digitalWrite(PIN_THERM, HIGH);
+
+  #ifdef IO_EXPANDER
+    Wire.begin();
+    ioCon1.pinMode(PIN_THERM, OUTPUT);
+    ioCon1.digitalWrite(PIN_THERM, HIGH); 
+  #else
+    pinMode(PIN_THERM, OUTPUT);
+    digitalWrite(PIN_THERM, HIGH);
+  #endif
 
 #ifdef PIN_SG1
   //Smartgrid pins - Set first to the inactive state, before configuring as outputs (avoid false triggering when initializing)
-  digitalWrite(PIN_SG1, SG_RELAY_INACTIVE_STATE);
-  digitalWrite(PIN_SG2, SG_RELAY_INACTIVE_STATE);
-  pinMode(PIN_SG1, OUTPUT);
-  pinMode(PIN_SG2, OUTPUT);
+  #ifdef IO_EXPANDER
+    ioCon1.digitalWrite(PIN_SG1, SG_RELAY_INACTIVE_STATE);
+    ioCon1.digitalWrite(PIN_SG2, SG_RELAY_INACTIVE_STATE);
+    ioCon1.pinMode(PIN_SG1, OUTPUT);
+    ioCon1.pinMode(PIN_SG2, OUTPUT);
+  #else
+    digitalWrite(PIN_SG1, SG_RELAY_INACTIVE_STATE);
+    digitalWrite(PIN_SG2, SG_RELAY_INACTIVE_STATE);
+    pinMode(PIN_SG1, OUTPUT);
+    pinMode(PIN_SG2, OUTPUT);
+  #endif
+  
+
 
 #endif
 #ifdef ARDUINO_M5Stick_C_Plus

--- a/src/setup.h
+++ b/src/setup.h
@@ -27,6 +27,8 @@
 #define TX_PIN    17// Pin connected to the RX pin of X10A
 #endif
 
+#define IO_EXPANDER         // use i2c port expander
+
 #define PIN_THERM 0// Pin connected to the thermostat relay (normally open)
 
 //Smart grid control - Optional:


### PR DESCRIPTION
Hi,
I added support for the port expander (https://shop.m5stack.com/products/official-extend-serial-i-o-unit). For me that is the basis adding the x85a feature in future.
You just have to install that https://github.com/AD0ND/PCA9554 library first. Then it's working fine for me.
Rememer that the default SG1 and SG2 ports are used by the i2c communication. Change them to what ever suits you on the expander.
As it's my first pull request, please tell me if i did something wrong...
Yours, markus
