### PR TITLE
Support for ESP32-CAM modules

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -36,6 +36,23 @@ upload_speed = 115200
 lib_deps =
 	PubSubClient
 
+[env:esp32-cam]
+platform = espressif32
+board = esp32cam
+framework = arduino
+board_build.partitions = min_spiffs.csv
+monitor_speed = 115200
+upload_speed = 115200
+; Uncomment this line to allow for remote upgrade. If name resolution does not work for you, replace with the IP of ESPAltherma
+; upload_port = ESPAltherma.local
+; Uncomment this line if you want to define the protocol. Autodetected otherwise.
+; upload_protocol = espota
+; upload_flags =
+;     --host_port=45678
+
+lib_deps =
+	PubSubClient
+
 [env:m5stickc]
 platform = espressif32
 board = m5stick-c

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -224,6 +224,7 @@ void setup()
   mqttSerial.print("Setting up wifi...");
   setup_wifi();
   ArduinoOTA.setHostname("ESPAltherma");
+  ArduinoOTA.setTimeout(3000);
   ArduinoOTA.onStart([]() {
     busy = true;
   });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,6 +201,11 @@ void setup()
   pinMode(PIN_THERM, OUTPUT);
   digitalWrite(PIN_THERM, HIGH);
 
+#ifdef PIN_LED
+  // LED for WiFi indicator
+  pinMode(PIN_LED, OUTPUT);
+#endif
+
 #ifdef PIN_SG1
   //Smartgrid pins - Set first to the inactive state, before configuring as outputs (avoid false triggering when initializing)
   digitalWrite(PIN_SG1, SG_RELAY_INACTIVE_STATE);
@@ -255,8 +260,16 @@ void loop()
   unsigned long start = millis();
   if (WiFi.status() != WL_CONNECTED)
   { //restart board if needed
+#ifdef PIN_LED
+    digitalWrite(PIN_LED, HIGH);
+#endif
     checkWifi();
   }
+
+#ifdef PIN_LED
+  digitalWrite(PIN_LED, LOW);
+#endif
+
   if (!client.connected())
   { //(re)connect to MQTT if needed
     reconnectMqtt();

--- a/src/setup.h
+++ b/src/setup.h
@@ -100,3 +100,6 @@
 #ifndef PROTOCOL
 #define PROTOCOL 'I'
 #endif
+
+// LED pin to use with WiFi indicator (if present)
+//#define PIN_LED 33


### PR DESCRIPTION
Although [Ai-Thinker ESP32-CAM](http://www.ai-thinker.com/pro_view-24.html) module and the clones _can_ work with the generic `esp32` environment, there are some specifics different from the `esp32doit-devkit-v1` board configuration used in it.

With this change OTA actually works fine through the following changes:
 - board configuration set to `esp32cam`
 - partitions spec set to `min_spiffs.csv`, which allows for OTA partitions to be set up on the image (unlike the default one)
 - `ArduinoOTA` timeout changed from the default 1s to 3s — I found that otherwise it bails out too often before completing, especially if the wireless connection isn't ideal

Additionally, this adds a helpful WiFi status indication through the on-board red LED present on those modules at pin `33`. When set to `LOW` it will turn on and it will turn off when set to `HIGH`.