### PR TITLE
README: fix new template format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Eg. this template declares the 2 operation modes as entities, the DHW tank tempe
 ```yaml
 template:
   - unique_id: "espaltherma"  # will be prefixed to all unique IDs
-    sensors:
+    sensor:
     - name: "Operation mode"
       unique_id: "operation"
       state: "{{ state_attr('sensor.althermasensors','Operation Mode') }}"


### PR DESCRIPTION
See https://www.home-assistant.io/integrations/template/#configuration-variables

```yaml
# Example configuration entry
template:
  - trigger:
      - platform: time_pattern
        # This will update every night
        hours: 0
        minutes: 0
    sensor:
      # Keep track how many days have past since a date
      - name: "Not smoking"
        state: '{{ ( ( as_timestamp(now()) - as_timestamp(strptime("06.07.2018", "%d.%m.%Y")) ) / 86400 ) | round(default=0) }}'
        unit_of_measurement: "Days"
```