### PR TITLE
#170 Pulse meter

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,11 @@ Depending on your HP model, SG3 might be configurable in "ECO mode", "Normal mod
 
 Note: Smart Grid needs to be switched ON in the heatpump configuration menu, otherwise SG1 and SG2 contacts are not evaluated.
 
+## Step 5 (optional) - Pulse Meter feature
+ESPaltherma can communicate how much energy it should consume via a pulse meter. For this, uncomment and confugre PIN_PULSE`, `PULSE_PER_kWh` and `PULSE_DURATION_MS` in `src/setup.c`. Send energy amount in Watt to MQTT channel `espaltherma/pulse/set`. Current Watt setting is available in `espaltherma/pulse/state`.  
+
+*TODO more close description what it is to do*
+
 # Troubleshooting
 
 ## Specific issues with M5

--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -91,7 +91,7 @@ void reconnectMqtt()
 #endif
 #ifdef PIN_PULSE
       // Pulse Meter
-      client.publish("homeassistant/select/espAltherma/pulse/config", "{\"availability\":[{\"topic\":\"espaltherma\/LWT\",\"payload_available\":\"Online\",\"payload_not_available\":\"Offline\"}],\"availability_mode\":\"all\",\"unique_id\":\"espaltherma_grid\",\"device\":{\"identifiers\":[\"ESPAltherma\"],\"manufacturer\":\"ESPAltherma\",\"model\":\"M5StickC PLUS ESP32-PICO\",\"name\":\"ESPAltherma\"},\"icon\":\"mdi:meter-electric\",\"name\":\"EspAltherma Power Limitation\",\"command_topic\":\"espaltherma\/pulse\/set\",\"state_topic\":\"espaltherma\/pulse\/state\"}", true);
+      client.publish("homeassistant/number/espAltherma/pulse/config", "{\"availability\":[{\"topic\":\"espaltherma/LWT\",\"payload_available\":\"Online\",\"payload_not_available\":\"Offline\"}],\"availability_mode\":\"all\",\"unique_id\":\"espaltherma_grid\",\"device\":{\"identifiers\":[\"ESPAltherma\"],\"manufacturer\":\"ESPAltherma\",\"model\":\"M5StickC PLUS ESP32-PICO\",\"name\":\"ESPAltherma\"},\"icon\":\"mdi:meter-electric\",\"name\":\"EspAltherma Power Limitation\",\"min\":0,\"max\":90000,\"mode\":\"box\",\"unit_of_measurement\":\"W\",\"command_topic\":\"espaltherma/pulse/set\",\"state_topic\":\"espaltherma/pulse/state\"}", true);
       client.subscribe("espaltherma/pulse/set");
       client.publish("espaltherma/pulse/state", "0");
 #endif
@@ -205,7 +205,9 @@ hw_timer_t * timerPulseEnd = NULL;
 // hardware timer callback for when the pulse should start
 void IRAM_ATTR onPulseStartTimer()
 {
-  // digitalWrite(LED_BUILTIN, HIGH);
+  #ifdef PULSE_LED_BUILTIN
+    digitalWrite(LED_BUILTIN, HIGH);
+  #endif
   digitalWrite(PIN_PULSE, HIGH);
 
   timerWrite(timerPulseEnd, 0);
@@ -217,7 +219,9 @@ void IRAM_ATTR onPulseStartTimer()
 // hardware timer callback when the pulse duration is over
 void IRAM_ATTR onPulseEndTimer()
 {
-  // digitalWrite(LED_BUILTIN, LOW);
+  #ifdef PULSE_LED_BUILTIN
+    digitalWrite(LED_BUILTIN, LOW);
+  #endif
   digitalWrite(PIN_PULSE, LOW);
 
   timerWrite(timerPulseStart, 0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -212,6 +212,9 @@ void setup()
 #endif
 #ifdef PIN_PULSE
   pinMode(PIN_PULSE, OUTPUT);
+  #ifdef PULSE_LED_BUILTIN
+    pinMode(LED_BUILTIN, OUTPUT);
+  #endif
 #endif
 #ifdef ARDUINO_M5Stick_C_Plus
   gpio_pulldown_dis(GPIO_NUM_25);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,6 +83,8 @@ void extraLoop()
 {
   client.loop();
   ArduinoOTA.handle();
+  // give interrupts time
+  vTaskDelay(0);
   while (busy)
   { //Stop processing during OTA
     ArduinoOTA.handle();
@@ -207,7 +209,9 @@ void setup()
   digitalWrite(PIN_SG2, SG_RELAY_INACTIVE_STATE);
   pinMode(PIN_SG1, OUTPUT);
   pinMode(PIN_SG2, OUTPUT);
-
+#endif
+#ifdef PIN_PULSE
+  pinMode(PIN_PULSE, OUTPUT);
 #endif
 #ifdef ARDUINO_M5Stick_C_Plus
   gpio_pulldown_dis(GPIO_NUM_25);

--- a/src/setup.h
+++ b/src/setup.h
@@ -31,9 +31,8 @@
 
 //Smart grid control - Optional:
 //Uncomment and set to enable SG mqtt functions
-// TODO comment
-#define PIN_SG1 32// Pin connected to dry contact SG 1 relay (normally open)
-#define PIN_SG2 33// Pin connected to dry contact SG 2 relay (normally open)
+// #define PIN_SG1 32// Pin connected to dry contact SG 1 relay (normally open)
+// #define PIN_SG2 33// Pin connected to dry contact SG 2 relay (normally open)
 // Define if your SG relay board is Low or High triggered (signal pins)
 // Only uncomment one of them
 #define SG_RELAY_HIGH_TRIGGER
@@ -41,10 +40,10 @@
 
 //Pulse Meter control - Optional:
 //Uncomment and set to enable Pulse Meter mqtt functions
-// TODO commented by default
-#define PIN_PULSE 25// Pin connected to dry contact SG 1 relay (normally open)
+// #define PIN_PULSE 25// Pin connected to pulse meter relay
+// #define PULSE_LED_BUILTIN 1 // also pulse the build in LED
 #define PULSE_PER_kWh 1000  // match setting on HP (TODO hint for setting path)
-#define PULSE_DURATION_MS 100  // Duration of the pulse, decrease on very high energy settings (TODO give example)
+#define PULSE_DURATION_MS 200  // Duration of the pulse, decrease on very high energy settings (TODO give example)
 
 // DO NOT CHANGE: Defines the SG active/inactive relay states, according to the definition of the trigger status
 #if defined(SG_RELAY_LOW_TRIGGER)

--- a/src/setup.h
+++ b/src/setup.h
@@ -31,12 +31,20 @@
 
 //Smart grid control - Optional:
 //Uncomment and set to enable SG mqtt functions
-//#define PIN_SG1 32// Pin connected to dry contact SG 1 relay (normally open)
-//#define PIN_SG2 33// Pin connected to dry contact SG 2 relay (normally open)
+// TODO comment
+#define PIN_SG1 32// Pin connected to dry contact SG 1 relay (normally open)
+#define PIN_SG2 33// Pin connected to dry contact SG 2 relay (normally open)
 // Define if your SG relay board is Low or High triggered (signal pins)
 // Only uncomment one of them
 #define SG_RELAY_HIGH_TRIGGER
 //#define SG_RELAY_LOW_TRIGGER
+
+//Pulse Meter control - Optional:
+//Uncomment and set to enable Pulse Meter mqtt functions
+// TODO commented by default
+#define PIN_PULSE 25// Pin connected to dry contact SG 1 relay (normally open)
+#define PULSE_PER_kWh 1000  // match setting on HP (TODO hint for setting path)
+#define PULSE_DURATION_MS 100  // Duration of the pulse, decrease on very high energy settings (TODO give example)
 
 // DO NOT CHANGE: Defines the SG active/inactive relay states, according to the definition of the trigger status
 #if defined(SG_RELAY_LOW_TRIGGER)


### PR DESCRIPTION
This adds support for pulse meter to indicate the HP the desired power consumption in combination with the smart grid functionality.

**Final Usage**
Is as simple as the SG functionality, set the desired power usage in MQTT. Value is interpreted in watt. If you use Home Assistant, it will - similar to SG - auto-configure an input field, where you can set the available/desired power usage.

**Hardware**
I made a board with optocouplers. I measured 12 V - 16 V on the contacts and used the "LTV 815" optocoupler. I am not an electrical engineer, so not sure if this is the right thing, but so far it works. I am using a esp-wroom-32 dev board.
Pulse meter cables were connected to S4S (X5M connections 3&4) connect. Watch for the polarity of the cables, the optocouplers only work when the current flows in the right direction.

**Alterma Setting**
This is the part where I am still trying to figure out what needs to be set up to respect the pulse meter in "recommended on" state. The pulse meter works - I tested it against an other ESP with esphome pulse meter setup.

Following for sure needs to be set:
[Installer Setting]/[Energy metering]/[Electricity meter 2]: change away from "None". Should be either "1000/kWh" or "1000/kWh for PV panel"

This one setting seemed not be sufficient, so I am still investigating.

For good measures, I have a Daikin Altherma 3 H HT F (ETVH16S23EA9W)

Still open:

- [ ]  Finish Readme
- [ ]  Act on too high watt setting, that cannot be safely transmitted (e.g. pulses faster than pulse length)

refs #170