### PR TITLE
Add missing 'break' after convertPress2Temp method call inside of switch case statement in convert function

### DIFF
--- a/include/converters.h
+++ b/include/converters.h
@@ -257,21 +257,27 @@ public:
         case 401:
             dblData = (double)getSignedValue(data, num, 0);
             dblData = convertPress2Temp(dblData);
+            break;
         case 402:
             dblData = (double)getSignedValue(data, num, 1);
             dblData = convertPress2Temp(dblData);
+            break;
         case 403:
             dblData = (double)getSignedValue(data, num, 0) / 256.0;
             dblData = convertPress2Temp(dblData);
+            break;
         case 404:
             dblData = (double)getSignedValue(data, num, 1) / 256.0;
             dblData = convertPress2Temp(dblData);
+            break;
         case 405:
             dblData = (double)getSignedValue(data, num, 0) * 0.1;
             dblData = convertPress2Temp(dblData);
+            break;
         case 406:
             dblData = (double)getSignedValue(data, num, 1) * 0.1;
             dblData = convertPress2Temp(dblData);
+            break;
 
         default:
             // conversion is not available


### PR DESCRIPTION
Adding missing break statement after convertPress2Temp method calls to avoid returning 'Conv <401-406> not avail' for all  pressure to temp conversions performed in convert function.