### PR TITLE
Support added for encrypted mqtt connections

### DIFF
--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -17,7 +17,12 @@ char jsonbuff[MAX_MSG_SIZE] = "[{\0";
 char jsonbuff[MAX_MSG_SIZE] = "{\0";
 #endif
 
+#ifdef MQTT_ENCRYPTED
+#include <WiFiClientSecure.h>
+WiFiClientSecure espClient;
+#else
 WiFiClient espClient;
+#endif
 PubSubClient client(espClient);
 
 void sendValues()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -300,11 +300,21 @@ void setup()
   });
   ArduinoOTA.begin();
 
-  client.setServer(MQTT_SERVER, MQTT_PORT);
+  #ifdef MQTT_ENCRYPTED
+  // Required to establish encrypted connections. 
+  // If you want to be more secure here, you can use the CA certificate to allow the wifi client to verify the other party. NOTE: If you use the CA certificate here, then you need to make sure to update it here regulary!
+  espClient.setInsecure();
+  espClient.setTimeout(5);
+  #endif
+
   client.setBufferSize(MAX_MSG_SIZE); //to support large json message
   client.setCallback(callback);
   client.setServer(MQTT_SERVER, MQTT_PORT);
-  mqttSerial.print("Connecting to MQTT server...");
+
+  auto timeout = espClient.getTimeout();
+  Serial.printf("Wifi client timeout: %d\n", timeout);
+
+  mqttSerial.printf("Connecting to MQTT server: %s:%d\n", MQTT_SERVER, MQTT_PORT);
   mqttSerial.begin(&client, "espaltherma/log");
   reconnectMqtt();
   mqttSerial.println("OK!");

--- a/src/setup.h
+++ b/src/setup.h
@@ -14,6 +14,7 @@
 #define MQTT_USERNAME ""//leave empty if not set (bad!)
 #define MQTT_PASSWORD ""//leave empty if not set (bad!)
 #define MQTT_PORT 1883
+//#define MQTT_ENCRYPTED // uncomment if MQTT connection is encrypted via TLS
 
 #define FREQUENCY 30000 //query values every 30 sec
 


### PR DESCRIPTION
I just got my hardware yesterday and had troubles connecting to my mqtt server.
Turns out, that the current program only supported unencrypted mqtt connections.

I have added support for it, which can be enabled by uncommenting the MQTT_ENCRYPTED define in the setup.h file.
Publishing the fix here in case someone else also runs into the same issue.