### PR TITLE
M5Stack Tough Support Added

### DIFF
--- a/include/mqttserial.h
+++ b/include/mqttserial.h
@@ -8,6 +8,8 @@
 #include <M5StickCPlus.h>
 #elif ARDUINO_M5Stick_C
 #include <M5StickC.h>
+#elif ARDUINO_M5Stack_Tough
+#include <M5Tough.h>
 #endif
 class MQTTSerial: public Stream
 {
@@ -61,7 +63,7 @@ MQTTSerial::MQTTSerial()
 }
 size_t MQTTSerial::write(const uint8_t *buffer, size_t size)
 {
-#ifdef ARDUINO_M5Stick_C
+#if defined(ARDUINO_M5Stick_C) || defined(ARDUINO_M5Stack_Tough)
     if (M5.Lcd.getCursorY()+13>M5.Lcd.height()){
         M5.Lcd.fillScreen(TFT_BLACK);
         M5.Lcd.setCursor(0,0);

--- a/platformio.ini
+++ b/platformio.ini
@@ -85,6 +85,22 @@ lib_deps =
 
 build_flags = "-D ARDUINO_M5Stick_C_Plus2"
 
+[env:m5stack-tough]
+platform = espressif32
+board = m5stack-core2
+framework = arduino
+monitor_speed = 115200
+upload_speed = 115200
+; Uncomment this line to allow for remote upgrade. If name resolution does not work for you, replace with the IP of ESPAltherma
+; upload_port = ESPAltherma.local
+; Uncomment this line if you want to define the protocol. Autodetected otherwise.
+; upload_protocol = espota
+
+lib_deps = https://github.com/m5stack/M5Tough.git
+		   PubSubClient
+
+build_flags = "-D ARDUINO_M5Stack_Tough"
+
 [env:native]
 # Used to run unit test; g++ must be in PATH.
 platform = native

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,7 +126,7 @@ void extraLoop()
     LCDTimeout = millis() + 30000;
     display_sleeping = false;
 
-  }else if (LCDTimeout < millis() & !display_sleeping){//Turn screen off.
+  }else if (LCDTimeout < millis() && !display_sleeping){//Turn screen off.
     M5.Lcd.sleep();
     M5.Lcd.setBrightness(0);
     display_sleeping = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,8 @@
 #include <M5StickCPlus.h>
 #elif ARDUINO_M5Stick_C
 #include <M5StickC.h>
+#elif ARDUINO_M5Stack_Tough
+#include <M5Tough.h>
 #else
 #include <Arduino.h>
 #endif
@@ -35,7 +37,7 @@ Converter converter;
 char registryIDs[32]; //Holds the registries to query
 bool busy = false;
 
-#if defined(ARDUINO_M5Stick_C) || defined(ARDUINO_M5Stick_C_Plus)
+#if defined(ARDUINO_M5Stick_C) || defined(ARDUINO_M5Stick_C_Plus) || defined(ARDUINO_M5Stack_Tough)
 long LCDTimeout = 40000;//Keep screen ON for 40s then turn off. ButtonA will turn it On again.
 #endif
 
@@ -85,6 +87,7 @@ void updateValues(char regID)
 }
 
 uint16_t loopcount =0;
+boolean display_sleeping = false;
 
 void extraLoop()
 {
@@ -112,6 +115,21 @@ void extraLoop()
     LCDTimeout = millis() + 30000;
   } else if (LCDTimeout < millis()) { //Turn screen off.
     M5.Display.sleep();
+  }
+  M5.update();
+#endif
+
+#ifdef ARDUINO_M5Stack_Tough
+  if (M5.Touch.changed){//Turn back ON screen
+    M5.Lcd.setBrightness(12);
+    M5.Lcd.wakeup();
+    LCDTimeout = millis() + 30000;
+    display_sleeping = false;
+
+  }else if (LCDTimeout < millis() & !display_sleeping){//Turn screen off.
+    M5.Lcd.sleep();
+    M5.Lcd.setBrightness(0);
+    display_sleeping = true;
   }
   M5.update();
 #endif
@@ -258,7 +276,7 @@ void initRegistries(){
 }
 
 void setupScreen(){
-#if !defined(ARDUINO_M5Stick_C_Plus2) && defined(ARDUINO_M5Stick_C) || defined(ARDUINO_M5Stick_C_Plus) 
+#if !defined(ARDUINO_M5Stick_C_Plus2) && defined(ARDUINO_M5Stick_C) || defined(ARDUINO_M5Stick_C_Plus) || defined(ARDUINO_M5Stack_Tough)
   M5.begin();
 #if !defined(ARDUINO_M5Stick_C_Plus2)
   M5.Axp.EnableCoulombcounter();

--- a/src/setup.h
+++ b/src/setup.h
@@ -18,7 +18,7 @@
 
 #define FREQUENCY 30000 //query values every 30 sec
 
-#if defined(ARDUINO_M5Stick_C) || defined(ARDUINO_M5Stick_C_Plus) || defined(ARDUINO_M5Stick_C_Plus2)
+#if defined(ARDUINO_M5Stick_C) || defined(ARDUINO_M5Stick_C_Plus) || defined(ARDUINO_M5Stick_C_Plus2)  || defined(ARDUINO_M5Stack_Tough)
 // Values used when M5StickC, M5STickCPlus or M5Stick_C_Plus2 environment is selected:
 #define RX_PIN    36// Pin connected to the TX pin of X10A 
 #define TX_PIN    26// Pin connected to the RX pin of X10A


### PR DESCRIPTION
Added support for the M5Stack Tough. Seems to be all running fine on my heat pump.

https://docs.m5stack.com/en/core/tough

It is connected via the GPIO port which are the same pins as the M5Stick C Plus and others.  