### PR TITLE
Include support for HTTPS POST of data to HTTPS Server (e.g. emoncms.org for heatpumpmonitor.org)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ _If this project has any value for you, please consider [buying me a 🍺](https
     <li>Needs just an ESP32, no need for extra hardware. ESP8266 is also supported.</li>
     <li>Queries the Altherma for selected values at defined interval.</li>
     <li>Converts and formalizes all values in a JSON message sent over MQTT.</li>
+    <li>Converts and formalizes all values in a JSON message sent over HTTPS.</li>
     <li>Easily integrates with Home Assistant's MQTT auto-discovery.</li>
     <li>Supports update OverTheAir</li>
     <li>Log messages in Serial + MQTT + Screen (m5StickC)</li>

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ If you are using an **ESP8266** select the `nodemcuv2` environement.
 
 3. Edit the file `src/setup.h` as follows:
     - enter your wifi and mqtt settings
+    - if you want to send via HTTPS, update the HTTPS section lower down the file
     - select your RX TX GPIO pins connected to the X10A port. *The ESP32 has 3 serial ports. The first one, Serial0 is reserved for ESP<-USB->PC communication and ESP Altherma uses the Serial0 for logging (as any other project would do). So if you open the serial monitor on your PC, you'll see some debug from ESPAltherma. ESP32 can map any GPIO to the serial ports. Do NOT use the main Serial0 GPIOs RX0/TX0.* * The ESP8266 only has 1.5 Serial ports so it uses a software based serial driver. You can choose any pins, but some will stop you from being able to use the console*
 
       For ESP32 try to stick to the RX2/TX2 of your board (probably GPIO16/GPIO17). **For M5StickC or M5StickCPlus, 26 and 36 will automatically be used if you selected the corresponding environment**. For ESP8266 pins 4 & 5 (D2 & D1 on the NodeMCUv2) are known to work well. 

--- a/include/https.h
+++ b/include/https.h
@@ -1,0 +1,52 @@
+#include <HttpClient.h>
+#include <WiFiClientSecure.h>
+#include "setup.h"
+#ifdef ARDUINO_M5Stick_C_Plus2
+#include <M5StickCPlus2.h>
+#elif ARDUINO_M5Stick_C_Plus
+#include <M5StickCPlus.h>
+#elif ARDUINO_M5Stick_C
+#include <M5StickC.h>
+#endif
+
+void posthttps(char* httpsbuff) 
+{
+String httpRequestData = "node=" + String(NODE) + "&data=" + String(httpsbuff) + "&apikey=" + APIKEY;  //Build the Emoncms data string
+
+static WiFiClientSecure client;
+  if (!client) {
+    client.setCACert(rootCACertificate);
+  }
+
+    // setup https
+  HTTPClient https; 
+
+  if (https.begin(client, HTTP_SERVER)) {
+      Serial.print("[HTTPS] POST...\n");
+      M5.Lcd.print("[HTTPS] POST...\n");
+      https.addHeader("Content-Type", "application/x-www-form-urlencoded");
+    
+    // start connection and send HTTP header
+    int httpCode = https.POST(httpRequestData);
+    // httpCode will be negative on error
+    if (httpCode > 0) {
+      // HTTP header has been send and Server response header has been handled
+      Serial.printf("[HTTPS] POST... code: %d\n", httpCode);
+      M5.Lcd.printf("[HTTPS] POST... code: %d\n", httpCode);
+      // file found at server
+      if (httpCode == HTTP_CODE_OK || httpCode == HTTP_CODE_MOVED_PERMANENTLY) {
+        // print server response payload
+        String payload = https.getString();
+        Serial.println(payload);
+        M5.Lcd.println(payload);
+    }
+
+  }
+  else {
+   Serial.printf("[HTTPS] POST... failed, error: %s\n", https.errorToString(httpCode).c_str());
+   M5.Lcd.printf("[HTTPS] POST... failed, error: %s\n", https.errorToString(httpCode).c_str());
+  }
+
+  https.end();
+  }
+}

--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -1,6 +1,8 @@
 #include <PubSubClient.h>
 #include <EEPROM.h>
 #include "restart.h"
+#include "https.h"
+#include <string.h>
 
 #define MQTT_attr "espaltherma/ATTR"
 #define MQTT_lwt "espaltherma/LWT"
@@ -46,6 +48,10 @@ void sendValues()
   strcat(jsonbuff,"]");
 #endif
   client.publish(MQTT_attr, jsonbuff);
+  //M5.Lcd.println(jsonbuff); //Optional - prints the data to the screen if required
+  #ifdef HTTPS
+    posthttps(jsonbuff);
+  #endif
 #ifdef JSONTABLE
   strcpy(jsonbuff, "[{\0");
 #else

--- a/src/setup.h
+++ b/src/setup.h
@@ -1,3 +1,6 @@
+#ifndef SETUP_H //allow for additional .h files to include and compile
+#define SETUP_H //allow for additional .h files to include and compile
+
 //Setup your credentials and mqtt info here:
 //only change the value between the " " leave the rest of the line untouched.
 #define WIFI_SSID "SSID"//**Your SSID here**
@@ -130,3 +133,51 @@
 #ifndef PROTOCOL
 #define PROTOCOL 'I'
 #endif
+
+//Uncomment this to send HTTPS Messages
+// #define HTTPS
+// #define HTTP_SERVER "https://emoncms.org/input/post"  //emoncms
+
+// // only change the value between the " " leave the rest of the line untouched.
+// #define APIKEY "YOUR API KEY" //emoncms
+// #define NODE "YOUR NODE NAME" // node in emoncms
+
+// // root certificate of emoncms.org - expires 2038. You can include your own HTTPS server certificate in this format
+// // thanks to https://randomnerdtutorials.com/esp32-https-requests/ for the how-to
+// #define rootCACertificate \
+// "-----BEGIN CERTIFICATE-----\n" \
+// "MIIF3jCCA8agAwIBAgIQAf1tMPyjylGoG7xkDjUDLTANBgkqhkiG9w0BAQwFADCB\n" \
+// "iDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCk5ldyBKZXJzZXkxFDASBgNVBAcTC0pl\n" \
+// "cnNleSBDaXR5MR4wHAYDVQQKExVUaGUgVVNFUlRSVVNUIE5ldHdvcmsxLjAsBgNV\n" \
+// "BAMTJVVTRVJUcnVzdCBSU0EgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMTAw\n" \
+// "MjAxMDAwMDAwWhcNMzgwMTE4MjM1OTU5WjCBiDELMAkGA1UEBhMCVVMxEzARBgNV\n" \
+// "BAgTCk5ldyBKZXJzZXkxFDASBgNVBAcTC0plcnNleSBDaXR5MR4wHAYDVQQKExVU\n" \
+// "aGUgVVNFUlRSVVNUIE5ldHdvcmsxLjAsBgNVBAMTJVVTRVJUcnVzdCBSU0EgQ2Vy\n" \
+// "dGlmaWNhdGlvbiBBdXRob3JpdHkwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIK\n" \
+// "AoICAQCAEmUXNg7D2wiz0KxXDXbtzSfTTK1Qg2HiqiBNCS1kCdzOiZ/MPans9s/B\n" \
+// "3PHTsdZ7NygRK0faOca8Ohm0X6a9fZ2jY0K2dvKpOyuR+OJv0OwWIJAJPuLodMkY\n" \
+// "tJHUYmTbf6MG8YgYapAiPLz+E/CHFHv25B+O1ORRxhFnRghRy4YUVD+8M/5+bJz/\n" \
+// "Fp0YvVGONaanZshyZ9shZrHUm3gDwFA66Mzw3LyeTP6vBZY1H1dat//O+T23LLb2\n" \
+// "VN3I5xI6Ta5MirdcmrS3ID3KfyI0rn47aGYBROcBTkZTmzNg95S+UzeQc0PzMsNT\n" \
+// "79uq/nROacdrjGCT3sTHDN/hMq7MkztReJVni+49Vv4M0GkPGw/zJSZrM233bkf6\n" \
+// "c0Plfg6lZrEpfDKEY1WJxA3Bk1QwGROs0303p+tdOmw1XNtB1xLaqUkL39iAigmT\n" \
+// "Yo61Zs8liM2EuLE/pDkP2QKe6xJMlXzzawWpXhaDzLhn4ugTncxbgtNMs+1b/97l\n" \
+// "c6wjOy0AvzVVdAlJ2ElYGn+SNuZRkg7zJn0cTRe8yexDJtC/QV9AqURE9JnnV4ee\n" \
+// "UB9XVKg+/XRjL7FQZQnmWEIuQxpMtPAlR1n6BB6T1CZGSlCBst6+eLf8ZxXhyVeE\n" \
+// "Hg9j1uliutZfVS7qXMYoCAQlObgOK6nyTJccBz8NUvXt7y+CDwIDAQABo0IwQDAd\n" \
+// "BgNVHQ4EFgQUU3m/WqorSs9UgOHYm8Cd8rIDZsswDgYDVR0PAQH/BAQDAgEGMA8G\n" \
+// "A1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQEMBQADggIBAFzUfA3P9wF9QZllDHPF\n" \
+// "Up/L+M+ZBn8b2kMVn54CVVeWFPFSPCeHlCjtHzoBN6J2/FNQwISbxmtOuowhT6KO\n" \
+// "VWKR82kV2LyI48SqC/3vqOlLVSoGIG1VeCkZ7l8wXEskEVX/JJpuXior7gtNn3/3\n" \
+// "ATiUFJVDBwn7YKnuHKsSjKCaXqeYalltiz8I+8jRRa8YFWSQEg9zKC7F4iRO/Fjs\n" \
+// "8PRF/iKz6y+O0tlFYQXBl2+odnKPi4w2r78NBc5xjeambx9spnFixdjQg3IM8WcR\n" \
+// "iQycE0xyNN+81XHfqnHd4blsjDwSXWXavVcStkNr/+XeTWYRUc+ZruwXtuhxkYze\n" \
+// "Sf7dNXGiFSeUHM9h4ya7b6NnJSFd5t0dCy5oGzuCr+yDZ4XUmFF0sbmZgIn/f3gZ\n" \
+// "XHlKYC6SQK5MNyosycdiyA5d9zZbyuAlJQG03RoHnHcAP9Dc1ew91Pq7P8yF1m9/\n" \
+// "qS3fuQL39ZeatTXaw2ewh0qpKJ4jjv9cJ2vhsE/zB+4ALtRZh8tSQZXq9EfX7mRB\n" \
+// "VXyNWQKV3WKdwrnuWih0hKWbt5DHDAff9Yk2dDLWKMGwsAvgnEzDHNb842m1R0aB\n" \
+// "L6KCq9NjRHDEjf8tM7qtj3u1cIiuPhnPQCjY/MiQu12ZIvVS5ljFH4gxQ+6IHdfG\n" \
+// "jjxDah2nGN59PRbxYvnKkKj9\n" \
+// "-----END CERTIFICATE-----"
+
+#endif //SETUP_H


### PR DESCRIPTION
As a heat pump installer I am keen to make sure that I can provide the best service to my clients.
I also have some coding experience (not loads, so please go easy on me).
Daikin's StandByMe professional portal gives very limited data to the installer, whilst this project gives excellent coverage, and if implemented, would allow installers to really optimise their installations and up their game.
In order to draw the charts in the same format as heatpumpmonitor.org using the app in openenergymonitor.org, the data needs to be sent as a HTTP POST to an instance of emoncms (normally emoncms.org). I took this one step further and implemented HTTPS, which may be unnecessary, but offers future proofing.
After discussion on openenergymonitor forum, it was pointed out that if an installer wanted to do this, then they also would need a local MQTT broker and a means of forwarding the data as HTTP. This would normally mean a homeassistant device / raspberry PI as well (i.e. a second box of some type), and at this point it's inefficient for a heat pump installer to bring and setup all this kit, and could result in repeat visits to a client to resolve IT issues.
This pull request is to bring in the HTTPS POST directly into the main program, so that the option exists to send Daikin (and other brands) data directly via https post to emoncms and other web servers to allow for the charting to work from this data.
Thanks for your consideration