### PR TITLE
Restore SG state after reset or mqtt conn lost

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -328,7 +328,7 @@ void setup()
 #endif
 
   EEPROM.begin(10);
-  readEEPROM();//Restore previous state
+  restoreEEPROM();//Restore previous state
   mqttSerial.print("Setting up wifi...");
   setup_wifi();
   ArduinoOTA.setHostname("ESPAltherma");


### PR DESCRIPTION
Hi @raomin,

figured out that after a connection loss to the mqtt broker, the SG state is always broken/wrong. I'm now using EEPROM to store the SG state and the state of the pins. Also refactored/removed some functions since the names are not appropriate any more.

Cheers,
Daniel