### PR TITLE
Add setup constant to overrule ha discovery messages

### DIFF
--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -83,28 +83,36 @@ void reconnectMqtt()
     if (client.connect("ESPAltherma-dev", MQTT_USERNAME, MQTT_PASSWORD, MQTT_lwt, 0, true, "Offline"))
     {
       Serial.println("connected!");
+      #ifdef MQTT_HA_DISCOVERY
       client.publish("homeassistant/sensor/espAltherma/config", "{\"name\":\"AlthermaSensors\",\"stat_t\":\"~/LWT\",\"avty_t\":\"~/LWT\",\"pl_avail\":\"Online\",\"pl_not_avail\":\"Offline\",\"uniq_id\":\"espaltherma\",\"device\":{\"identifiers\":[\"ESPAltherma\"]}, \"~\":\"espaltherma\",\"json_attr_t\":\"~/ATTR\"}", true);
-      client.publish(MQTT_lwt, "Online", true);
       client.publish("homeassistant/switch/espAltherma/config", "{\"name\":\"Altherma\",\"cmd_t\":\"~/POWER\",\"stat_t\":\"~/STATE\",\"pl_off\":\"OFF\",\"pl_on\":\"ON\",\"~\":\"espaltherma\"}", true);
+      #endif
+      client.publish(MQTT_lwt, "Online", true);
 
       // Subscribe
       client.subscribe("espaltherma/POWER");
 #ifdef PIN_SG1
       // Smart Grid
+      #ifdef MQTT_HA_DISCOVERY
       client.publish("homeassistant/select/espAltherma/sg/config", "{\"availability\":[{\"topic\":\"espaltherma/LWT\",\"payload_available\":\"Online\",\"payload_not_available\":\"Offline\"}],\"availability_mode\":\"all\",\"unique_id\":\"espaltherma_sg\",\"device\":{\"identifiers\":[\"ESPAltherma\"],\"manufacturer\":\"ESPAltherma\",\"model\":\"M5StickC PLUS ESP32-PICO\",\"name\":\"ESPAltherma\"},\"icon\":\"mdi:solar-power\",\"name\":\"EspAltherma Smart Grid\",\"command_topic\":\"espaltherma/sg/set\",\"command_template\":\"{% if value == 'Free Running' %} 0 {% elif value == 'Forced Off' %} 1 {% elif value == 'Recommended On' %} 2 {% elif value == 'Forced On' %} 3 {% else %} 0 {% endif %}\",\"options\":[\"Free Running\",\"Forced Off\",\"Recommended On\",\"Forced On\"],\"state_topic\":\"espaltherma/sg/state\",\"value_template\":\"{% set mapper = { '0':'Free Running', '1':'Forced Off', '2':'Recommended On', '3':'Forced On' } %} {% set word = mapper[value] %} {{ word }}\"}", true);
+      #endif
       client.subscribe("espaltherma/sg/set");
       client.publish("espaltherma/sg/state", "0");
 #endif
 
 #ifdef SAFETY_RELAY_PIN
       // Safety relay
+      #ifdef MQTT_HA_DISCOVERY
       client.publish("homeassistant/switch/espAltherma/safety/config", "{\"name\":\"Altherma Safety\",\"cmd_t\":\"~/SAFETY\",\"stat_t\":\"~/SAFETY_STATE\",\"pl_off\":\"0\",\"pl_on\":\"1\",\"~\":\"espaltherma\"}", true);
+      #endif
       client.subscribe("espaltherma/SAFETY");
 #endif
 
 #ifndef PIN_SG1
+      #ifdef MQTT_HA_DISCOVERY
       // Publish empty retained message so discovered entities are removed from HA
       client.publish("homeassistant/select/espAltherma/sg/config", "", true);
+      #endif
 #endif
     }
     else

--- a/src/setup.h
+++ b/src/setup.h
@@ -15,6 +15,7 @@
 #define MQTT_PASSWORD ""//leave empty if not set (bad!)
 #define MQTT_PORT 1883
 //#define MQTT_ENCRYPTED // uncomment if MQTT connection is encrypted via TLS
+#define MQTT_HA_DISCOVERY // comment to disable HomeAssistant discovery messages
 
 #define FREQUENCY 30000 //query values every 30 sec
 


### PR DESCRIPTION
For openHAB or ioBroker users like me, it could be annoying and unnecessary to have HomeAssistant discovery messages in the MQTT broker. Therefore one should be able to disable those messages. This is a simple and quick solution for that.