### PR TITLE
Support for M5 NanoC6 and AtomS3-Lite boards

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,6 +12,55 @@
 [platformio]
 default_envs = esp32
 
+[m5base]
+framework = arduino
+upload_speed = 1500000
+monitor_speed = 9600
+
+
+[env:m5stack-atoms3]	
+extends = m5base
+platform = espressif32@6.3.2
+board = m5stack-atoms3
+build_flags = 
+	-D CORE_DEBUG_LEVEL=5
+	-D ARDUINO_USB_MODE=1
+	-D ARDUINO_USB_CDC_ON_BOOT=1
+	-D ARDUINO_M5Stick_Atom3S_Lite
+lib_deps = 
+	PubSubClient
+	m5stack/M5Unified@^0.2.2
+	m5stack/M5AtomS3@^1.0.1
+	fastled/FastLED@^3.9.12
+	Wire
+
+[m5stack-nanoC6]
+extends = m5base
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/51.03.07/platform-espressif32.zip
+board = m5stack-nanoc6
+build_flags = 
+	-D CORE_DEBUG_LEVEL=5
+	-D ARDUINO_USB_MODE=1
+	-D ARDUINO_USB_CDC_ON_BOOT=1
+	-D ARDUINO_M5STACK_NANOC6
+lib_deps = 
+	PubSubClient
+	m5stack/M5Unified@^0.2.2
+	m5stack/M5NanoC6
+	fastled/FastLED@^3.9.12
+	Wire
+	adafruit/Adafruit NeoPixel@^1.12.4
+
+
+[env:m5stack-nanoC6-cable]
+	extends = m5stack-nanoC6
+
+
+[env:m5stack-nanoC6-OTA]
+	extends = m5stack-nanoC6
+	upload_protocol = espota
+	upload_port = xxx.xxx.xxx.xxx  # update device IP
+
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
@@ -19,7 +68,7 @@ board = nodemcuv2
 monitor_speed = 115200
 upload_speed = 921600
 build_flags = -D_GNU_SOURCE
-lib_deps =
+lib_deps = 
 	PubSubClient
 
 [env:esp32]
@@ -33,7 +82,7 @@ upload_speed = 115200
 ; Uncomment this line if you want to define the protocol. Autodetected otherwise.
 ; upload_protocol = espota
 
-lib_deps =
+lib_deps = 
 	PubSubClient
 
 [env:m5stickc]
@@ -47,7 +96,7 @@ upload_speed = 115200
 ; Uncomment this line if you want to define the protocol. Autodetected otherwise.
 ; upload_protocol = espota
 
-lib_deps =
+lib_deps = 
 	M5StickC
 	PubSubClient
 
@@ -62,7 +111,7 @@ upload_speed = 115200
 ; Uncomment this line if you want to define the protocol. Autodetected otherwise.
 ; upload_protocol = espota
 
-lib_deps =
+lib_deps = 
 	M5StickCPlus
 	PubSubClient
 
@@ -79,7 +128,7 @@ upload_speed = 115200
 ; Uncomment this line if you want to define the protocol. Autodetected otherwise.
 ; upload_protocol = espota
 
-lib_deps =
+lib_deps = 
 	M5StickCPlus2
 	PubSubClient
 
@@ -97,7 +146,7 @@ upload_speed = 115200
 ; upload_protocol = espota
 
 lib_deps = https://github.com/m5stack/M5Tough.git
-		   PubSubClient
+	PubSubClient
 
 build_flags = "-D ARDUINO_M5Stack_Tough"
 

--- a/src/setup.h
+++ b/src/setup.h
@@ -22,6 +22,14 @@
 // Values used when M5StickC, M5STickCPlus or M5Stick_C_Plus2 environment is selected:
 #define RX_PIN    36// Pin connected to the TX pin of X10A 
 #define TX_PIN    26// Pin connected to the RX pin of X10A
+#elif defined(ARDUINO_M5Stick_Atom3S_Lite)
+// Values used when M5Stick_Atom3S_Lite environment is selected (for groove connector):
+#define RX_PIN    32// Pin connected to the TX pin of X10A 
+#define TX_PIN    26// Pin connected to the RX pin of X10A
+#elif defined(ARDUINO_M5STACK_NANOC6)
+// Values used when ARDUINO_M5STACK_NANOC6 environment is selected (for groove connector):
+#define RX_PIN    2// Pin connected to the TX pin of X10A 
+#define TX_PIN    1// Pin connected to the RX pin of X10A
 #else 
 //Default GPIO PINs for Serial2:
 #define RX_PIN    16// Pin connected to the TX pin of X10A 


### PR DESCRIPTION
Adding support for [M5NanoC6](https://docs.m5stack.com/en/core/M5NanoC6) and AtomS3-Lite. ( Pins, libraries).

For NanoC6, it's flashing the RGB light if there is any MQTT or Tx/Rx error for feedback, since it has no screens.

Something went a bit off with formatting, but still sharing the solution.