### PR TITLE
Update R6T sensor description for Altherma 3 4-8kW

### DIFF
--- a/include/def/Altherma(EBLA-EDLA D series 4-8kW Monobloc).h
+++ b/include/def/Altherma(EBLA-EDLA D series 4-8kW Monobloc).h
@@ -154,7 +154,7 @@ LabelDef labelDefs[] = {
 //{0x61,8,105,2,1,"Inlet water temp.(R4T)"},
 //{0x61,10,105,2,1,"DHW tank temp. (R5T)"},
 //{0x61,12,105,2,1,"Indoor ambient temp. (R1T)"},
-//{0x61,14,105,2,1,"Ext. indoor ambient sensor (R6T)"},
+//{0x61,14,105,2,1,"Ext. outdoor ambient sensor (R6T)"},
 //{0x62,0,307,1,-1,"Data Enable/Disable"},
 //{0x62,1,152,1,-1,"Indoor Unit Address"},
 //{0x62,2,307,1,-1,"Reheat ON/OFF"},


### PR DESCRIPTION
Really minor fix but might avoid someone being caught out in the future, found out when setting up ESPAltherma for an EDLA08EV3 that this is linked to an additional outside sensor rather than an indoor sensor. 