### PR TITLE
Migrate to M5Unified library for the M5Stick family of devices

### DIFF
--- a/include/mqttserial.h
+++ b/include/mqttserial.h
@@ -2,14 +2,8 @@
 #define mqttSerial_h
 #include "Stream.h"
 #include <PubSubClient.h>
-#ifdef ARDUINO_M5Stick_C_Plus2
-#include <M5StickCPlus2.h>
-#elif ARDUINO_M5Stick_C_Plus
-#include <M5StickCPlus.h>
-#elif ARDUINO_M5Stick_C
-#include <M5StickC.h>
-#elif ARDUINO_M5Stack_Tough
-#include <M5Tough.h>
+#if defined(ARDUINO_M5Stick_C_Plus2) || defined(ARDUINO_M5Stick_C_Plus) || defined(ARDUINO_M5Stick_C) || defined(ARDUINO_M5Stack_Tough)
+#include <M5Unified.h>
 #endif
 class MQTTSerial: public Stream
 {

--- a/platformio.ini
+++ b/platformio.ini
@@ -48,7 +48,7 @@ upload_speed = 115200
 ; upload_protocol = espota
 
 lib_deps =
-	M5StickC
+	M5Unified
 	PubSubClient
 
 [env:m5stickcplus]
@@ -63,7 +63,7 @@ upload_speed = 115200
 ; upload_protocol = espota
 
 lib_deps =
-	M5StickCPlus
+	M5Unified
 	PubSubClient
 
 build_flags = "-D ARDUINO_M5Stick_C_Plus"
@@ -80,7 +80,7 @@ upload_speed = 115200
 ; upload_protocol = espota
 
 lib_deps =
-	M5StickCPlus2
+	M5Unified
 	PubSubClient
 
 build_flags = "-D ARDUINO_M5Stick_C_Plus2"
@@ -96,7 +96,7 @@ upload_speed = 115200
 ; Uncomment this line if you want to define the protocol. Autodetected otherwise.
 ; upload_protocol = espota
 
-lib_deps = https://github.com/m5stack/M5Tough.git
+lib_deps = M5Unified
 		   PubSubClient
 
 build_flags = "-D ARDUINO_M5Stack_Tough"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,5 @@
-#ifdef ARDUINO_M5Stick_C_Plus2
-#include <M5StickCPlus2.h>
-#elif ARDUINO_M5Stick_C_Plus
-#include <M5StickCPlus.h>
-#elif ARDUINO_M5Stick_C
-#include <M5StickC.h>
-#elif ARDUINO_M5Stack_Tough
-#include <M5Tough.h>
+#if defined(ARDUINO_M5Stick_C_Plus2) || defined(ARDUINO_M5Stick_C_Plus) || defined(ARDUINO_M5Stick_C) || defined(ARDUINO_M5Stack_Tough)
+#include <M5Unified.h>
 #else
 #include <Arduino.h>
 #endif


### PR DESCRIPTION
The device-specific libraries are deprecated and replaced by M5Unified. This fixes a compilation failure for the M5StickC-Plus2.

Resolves https://github.com/raomin/ESPAltherma/issues/533, https://github.com/raomin/ESPAltherma/issues/527.