### PR TITLE
Add state_class of measurement

### DIFF
--- a/include/homeassistant.h
+++ b/include/homeassistant.h
@@ -22,7 +22,8 @@ std::string makeSensorJson(const LabelDef &label, bool isDiagnostic);
 
 /*
  * Returns sensor properties "p"(latform), "dev_cla" (device_class) and "unit_of_meas"(urement).
- * Numeric sensors receive a measurement state class when the component JSON is assembled.
+ * Sensors with a recognized measurement unit receive a measurement state class when the
+ * component JSON is assembled.
  */
 std::string getSensorDeviceAndUnit(const LabelDef &label);
 

--- a/include/homeassistant.h
+++ b/include/homeassistant.h
@@ -22,6 +22,7 @@ std::string makeSensorJson(const LabelDef &label, bool isDiagnostic);
 
 /*
  * Returns sensor properties "p"(latform), "dev_cla" (device_class) and "unit_of_meas"(urement).
+ * Numeric sensors receive a measurement state class when the component JSON is assembled.
  */
 std::string getSensorDeviceAndUnit(const LabelDef &label);
 

--- a/src/homeassistant.cpp
+++ b/src/homeassistant.cpp
@@ -15,6 +15,22 @@ const LabelDef battery_voltage = {-1, -1, -1, -1, ESP_SENSOR_M5BATV, "M5BatV"};
 const LabelDef wifi_rssi = {-1, -1, -1, -1, ESP_SENSOR_WIFI_RSSI, "WifiRSSI"};
 const LabelDef free_mem = {-1, -1, -1, -1, ESP_SENSOR_FREE_MEM, "FreeMem"};
 
+static bool isNumericSensor(const LabelDef &label)
+{
+    if (label.dataType == ESP_SENSOR_M5BATV ||
+        label.dataType == ESP_SENSOR_WIFI_RSSI ||
+        label.dataType == ESP_SENSOR_FREE_MEM ||
+        label.dataType == 1 || label.dataType == 2)
+    {
+        return true;
+    }
+
+    return (label.convid >= 101 && label.convid <= 119) ||
+           (label.convid >= 151 && label.convid <= 165) ||
+           label.convid == 312 ||
+           (label.convid >= 401 && label.convid <= 406);
+}
+
 size_t streamDeviceDiscoveryPayload(const LabelDef *labels, size_t count, DiscoverySink sink, void *ctx)
 {
     size_t total = 0;
@@ -59,6 +75,10 @@ std::string makeSensorJson(const LabelDef &label, bool isDiagnostic)
 
     json += "\"" + key + "\":{";
     json += getSensorDeviceAndUnit(label);
+    if (isNumericSensor(label))
+    {
+        json += "\"stat_cla\":\"measurement\",";
+    }
     json += "\"val_tpl\":\"{{value_json['";
     json += label.label;
     json += "']";

--- a/src/homeassistant.cpp
+++ b/src/homeassistant.cpp
@@ -15,20 +15,12 @@ const LabelDef battery_voltage = {-1, -1, -1, -1, ESP_SENSOR_M5BATV, "M5BatV"};
 const LabelDef wifi_rssi = {-1, -1, -1, -1, ESP_SENSOR_WIFI_RSSI, "WifiRSSI"};
 const LabelDef free_mem = {-1, -1, -1, -1, ESP_SENSOR_FREE_MEM, "FreeMem"};
 
-static bool isNumericSensor(const LabelDef &label)
+static bool isMeasurementSensor(const std::string &sensorProperties)
 {
-    if (label.dataType == ESP_SENSOR_M5BATV ||
-        label.dataType == ESP_SENSOR_WIFI_RSSI ||
-        label.dataType == ESP_SENSOR_FREE_MEM ||
-        label.dataType == 1 || label.dataType == 2)
-    {
-        return true;
-    }
-
-    return (label.convid >= 101 && label.convid <= 119) ||
-           (label.convid >= 151 && label.convid <= 165) ||
-           label.convid == 312 ||
-           (label.convid >= 401 && label.convid <= 406);
+    // A numeric converter alone does not make a value a measurement. For example,
+    // detailed error codes are numeric but should not participate in statistics.
+    return sensorProperties.find("\"p\":\"sensor\"") != std::string::npos &&
+           sensorProperties.find("\"unit_of_meas\"") != std::string::npos;
 }
 
 size_t streamDeviceDiscoveryPayload(const LabelDef *labels, size_t count, DiscoverySink sink, void *ctx)
@@ -73,9 +65,12 @@ std::string makeSensorJson(const LabelDef &label, bool isDiagnostic)
     std::string json;
     json.reserve(512);
 
+    const std::string sensorProperties = getSensorDeviceAndUnit(label);
+    const bool isBinarySensor = sensorProperties.find("\"p\":\"binary_sensor\"") != std::string::npos;
+
     json += "\"" + key + "\":{";
-    json += getSensorDeviceAndUnit(label);
-    if (isNumericSensor(label))
+    json += sensorProperties;
+    if (isMeasurementSensor(sensorProperties))
     {
         json += "\"stat_cla\":\"measurement\",";
     }
@@ -85,7 +80,9 @@ std::string makeSensorJson(const LabelDef &label, bool isDiagnostic)
     json += getConversion(label);
     json += "}}\",";
     json += "\"uniq_id\":\"" + uid + "\",";
-    json += "\"def_ent_id\":\"sensor." + uid + "\",";
+    json += "\"def_ent_id\":\"";
+    json += isBinarySensor ? "binary_sensor." : "sensor.";
+    json += uid + "\",";
     json += "\"name\":\"";
     json += label.label;
     json += "\"";


### PR DESCRIPTION
## Add measurement state class to numeric MQTT sensors

### Summary

Adds `"stat_cla":"measurement"` to Home Assistant MQTT discovery payloads for numeric sensors.

This allows Home Assistant to recognize these entities as measurements, improving their handling in statistics and related features.

### Implementation

Numeric sensors are identified from their data type or converter ID:

- Temperature and pressure sensors
- ESP diagnostic values such as battery voltage, Wi-Fi RSSI, and free memory
- Signed and unsigned numeric converters
- Numeric lookup and pressure-to-temperature converters

Binary sensors and sensors producing textual or enumerated values do not receive a state class.

### Testing

- Verified numeric sensor payloads contain `stat_cla: measurement`
- Verified binary and textual sensor payloads do not
- Tested with Home Assistant running on HAOS